### PR TITLE
Document public interfaces properly

### DIFF
--- a/src/Tethos.FakeItEasy/AutoFakeItEasyContainer.cs
+++ b/src/Tethos.FakeItEasy/AutoFakeItEasyContainer.cs
@@ -2,9 +2,7 @@
 
 namespace Tethos.FakeItEasy
 {
-    /// <summary>
-    /// Auto-mocking contrainer for <see cref="FakeItEasy"/> concrete type.
-    /// </summary>
+    /// <inheritdoc cref="IAutoFakeItEasyContainer" />
     public class AutoFakeItEasyContainer : WindsorContainer, IAutoFakeItEasyContainer
     {
     }

--- a/src/Tethos.FakeItEasy/AutoFakeItEasyContainerFactory.cs
+++ b/src/Tethos.FakeItEasy/AutoFakeItEasyContainerFactory.cs
@@ -6,7 +6,7 @@
     public static class AutoFakeItEasyContainerFactory
     {
         /// <summary>
-        /// Creates ready to use auto-mocking ready.
+        /// Creates ready to use auto-mocking container.
         /// </summary>
         public static IAutoFakeItEasyContainer Create() => new AutoMockingTest().Container;
     }

--- a/src/Tethos.FakeItEasy/AutoFakeItEasyResolver.cs
+++ b/src/Tethos.FakeItEasy/AutoFakeItEasyResolver.cs
@@ -18,8 +18,12 @@ namespace Tethos.FakeItEasy
         }
 
         /// <inheritdoc />
-        public override bool CanResolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model, DependencyModel dependency)
-            => dependency.TargetType.IsClass || base.CanResolve(context, contextHandlerResolver, model, dependency);
+        public override bool CanResolve(
+            CreationContext context,
+            ISubDependencyResolver contextHandlerResolver,
+            ComponentModel model,
+            DependencyModel dependency
+        ) => dependency.TargetType.IsClass || base.CanResolve(context, contextHandlerResolver, model, dependency);
 
         /// <inheritdoc />
         public override object MapToTarget(Type targetType, Arguments constructorArguments)

--- a/src/Tethos.FakeItEasy/Tethos.FakeItEasy.csproj
+++ b/src/Tethos.FakeItEasy/Tethos.FakeItEasy.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<NoWarn>$(NoWarn);IDT001</NoWarn>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -50,6 +51,12 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Tethos\Tethos.csproj" />
+	</ItemGroup>
+
+	<!-- Following group is needed because of this: https://github.com/dotnet/standard/issues/1527 -->
+	<ItemGroup>
+		<PackageDownload Include="NETStandard.Library.Ref" Version="[2.1.0]" />
+		<InheritDocReference Include="$([MSBuild]::EnsureTrailingSlash('$(NugetPackageRoot)'))netstandard.library.ref\2.1.0\ref\netstandard2.1\netstandard.xml" />
 	</ItemGroup>
 
 </Project>

--- a/src/Tethos.Moq/AutoMoqContainer.cs
+++ b/src/Tethos.Moq/AutoMoqContainer.cs
@@ -2,9 +2,7 @@
 
 namespace Tethos.Moq
 {
-    /// <summary>
-    /// Auto-mocking contrainer for <see cref="Moq"/> concrete type.
-    /// </summary>
+    /// <inheritdoc cref="IAutoMoqContainer" />
     public class AutoMoqContainer : WindsorContainer, IAutoMoqContainer
     {
     }

--- a/src/Tethos.Moq/AutoMoqContainerFactory.cs
+++ b/src/Tethos.Moq/AutoMoqContainerFactory.cs
@@ -6,7 +6,7 @@
     public static class AutoMoqContainerFactory
     {
         /// <summary>
-        /// Creates ready to use auto-mocking ready.
+        /// Creates ready to use auto-mocking container.
         /// </summary>
         public static IAutoMoqContainer Create() => new AutoMockingTest().Container;
     }

--- a/src/Tethos.Moq/AutoMoqResolver.cs
+++ b/src/Tethos.Moq/AutoMoqResolver.cs
@@ -19,16 +19,20 @@ namespace Tethos.Moq
         }
 
         /// <inheritdoc />
-        public override bool CanResolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model, DependencyModel dependency) =>
-            dependency.TargetType.IsClass && context.AdditionalArguments.Any() // TODO: Add tests covering default ctor
+        public override bool CanResolve(
+            CreationContext context,
+            ISubDependencyResolver contextHandlerResolver,
+            ComponentModel model,
+            DependencyModel dependency
+        ) => dependency.TargetType.IsClass && context.AdditionalArguments.Any() // TODO: Add coverage for default ctor
             || base.CanResolve(context, contextHandlerResolver, model, dependency);
 
         /// <inheritdoc />
         public override object MapToTarget(Type targetType, Arguments constructorArguments)
         {
             var mockType = typeof(Mock<>).MakeGenericType(targetType);
-            var args = constructorArguments.Select(x => x.Value).ToArray();
-            var mock = Activator.CreateInstance(mockType, args) as Mock;
+            var arguments = constructorArguments.Select(x => x.Value).ToArray();
+            var mock = Activator.CreateInstance(mockType, arguments) as Mock;
 
             Kernel.Register(Component.For(mockType)
                 .Instance(mock)

--- a/src/Tethos.Moq/Tethos.Moq.csproj
+++ b/src/Tethos.Moq/Tethos.Moq.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<NoWarn>$(NoWarn);IDT001</NoWarn>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -50,6 +51,12 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Tethos\Tethos.csproj" />
+	</ItemGroup>
+
+	<!-- Following group is needed because of this: https://github.com/dotnet/standard/issues/1527 -->
+	<ItemGroup>
+		<PackageDownload Include="NETStandard.Library.Ref" Version="[2.1.0]" />
+		<InheritDocReference Include="$([MSBuild]::EnsureTrailingSlash('$(NugetPackageRoot)'))netstandard.library.ref\2.1.0\ref\netstandard2.1\netstandard.xml" />
 	</ItemGroup>
 
 </Project>

--- a/src/Tethos.NSubstitute/AutoNSubstituteContainer.cs
+++ b/src/Tethos.NSubstitute/AutoNSubstituteContainer.cs
@@ -2,9 +2,7 @@
 
 namespace Tethos.NSubstitute
 {
-    /// <summary>
-    /// Auto-mocking contrainer for <see cref="NSubstitute"/> concrete type.
-    /// </summary>
+    /// <inheritdoc cref="IAutoNSubstituteContainer" />
     public class AutoNSubstituteContainer : WindsorContainer, IAutoNSubstituteContainer
     {
     }

--- a/src/Tethos.NSubstitute/AutoNSubstituteContainerFactory.cs
+++ b/src/Tethos.NSubstitute/AutoNSubstituteContainerFactory.cs
@@ -6,7 +6,7 @@
     public static class AutoNSubstituteContainerFactory
     {
         /// <summary>
-        /// Creates ready to use auto-mocking ready.
+        /// Creates ready to use auto-mocking container.
         /// </summary>
         public static IAutoNSubstituteContainer Create() => new AutoMockingTest().Container;
     }

--- a/src/Tethos.NSubstitute/AutoNSubstituteResolver.cs
+++ b/src/Tethos.NSubstitute/AutoNSubstituteResolver.cs
@@ -18,13 +18,18 @@ namespace Tethos.NSubstitute
         }
 
         /// <inheritdoc />
-        public override bool CanResolve(CreationContext context, ISubDependencyResolver contextHandlerResolver, ComponentModel model, DependencyModel dependency)
-            => dependency.TargetType.IsClass || base.CanResolve(context, contextHandlerResolver, model, dependency);
+        public override bool CanResolve(
+            CreationContext context,
+            ISubDependencyResolver contextHandlerResolver,
+            ComponentModel model,
+            DependencyModel dependency
+        ) => dependency.TargetType.IsClass || base.CanResolve(context, contextHandlerResolver, model, dependency);
 
         /// <inheritdoc />
         public override object MapToTarget(Type targetType, Arguments constructorArguments)
         {
-            var mock = Substitute.For(new Type[] { targetType }, targetType.IsInterface ? Array.Empty<object>() : constructorArguments.Flatten());
+            var arguments = targetType.IsInterface ? Array.Empty<object>() : constructorArguments.Flatten();
+            var mock = Substitute.For(new Type[] { targetType }, arguments);
 
             Kernel.Register(Component.For(targetType)
                 .Instance(mock)

--- a/src/Tethos.NSubstitute/Tethos.NSubstitute.csproj
+++ b/src/Tethos.NSubstitute/Tethos.NSubstitute.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<NoWarn>$(NoWarn);IDT001</NoWarn>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -50,6 +51,12 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Tethos\Tethos.csproj" />
+	</ItemGroup>
+
+	<!-- Following group is needed because of this: https://github.com/dotnet/standard/issues/1527 -->
+	<ItemGroup>
+		<PackageDownload Include="NETStandard.Library.Ref" Version="[2.1.0]" />
+		<InheritDocReference Include="$([MSBuild]::EnsureTrailingSlash('$(NugetPackageRoot)'))netstandard.library.ref\2.1.0\ref\netstandard2.1\netstandard.xml" />
 	</ItemGroup>
 
 </Project>

--- a/src/Tethos/AssemblyExtensions.cs
+++ b/src/Tethos/AssemblyExtensions.cs
@@ -8,26 +8,37 @@ namespace Tethos
 {
     internal static class AssemblyExtensions
     {
-        internal static Assembly[] GetDependencies(this Assembly rootAssembly) =>
-            AppDomain.CurrentDomain.BaseDirectory.GetAssemblyFiles()
+        internal static Assembly[] GetDependencies(
+            this Assembly rootAssembly
+        ) => AppDomain.CurrentDomain.BaseDirectory.GetAssemblyFiles()
                 .FilterAssemblies(rootAssembly.GetPattern(), new[] { ".dll", ".exe" }, rootAssembly)
                 .ExcludeRefDirectory()
                 .ElseLoadReferencedAssemblies(rootAssembly)
                 .LoadAssemblies(rootAssembly)
                 .ToArray();
 
-        internal static IEnumerable<File> GetAssemblyFiles(this string directory) =>
-            Directory
+        internal static IEnumerable<File> GetAssemblyFiles(
+            this string directory
+        ) => Directory
                 .EnumerateFiles(directory, "*.*", SearchOption.AllDirectories)
                 .Select(filePath => filePath.GetFile());
 
-        internal static IEnumerable<File> FilterAssemblies(this IEnumerable<File> assemblies, string searchPattern, string[] allowedFileExtensions, params Assembly[] rootAssemblies) =>
-            assemblies
+        internal static IEnumerable<File> FilterAssemblies(
+            this IEnumerable<File> assemblies,
+            string searchPattern,
+            string[] allowedFileExtensions,
+            params Assembly[] rootAssemblies
+        ) => assemblies
                 .Where(file => allowedFileExtensions.Contains(file.Extension))
                 .Where(file => file.Name.Contains(searchPattern))
-                .Where(file => !rootAssemblies.Select(assembly => Path.GetFileName(assembly.Location)).Contains(file.Name));
+                .Where(file => !rootAssemblies
+                                    .Select(assembly => Path.GetFileName(assembly.Location))
+                                    .Contains(file.Name)
+                );
 
-        internal static string GetPattern(this Assembly rootAssembly)
+        internal static string GetPattern(
+            this Assembly rootAssembly
+        )
         {
             var patternSeparators = new[] { '.', ',' };
             var name = rootAssembly.FullName;
@@ -44,12 +55,16 @@ namespace Tethos
             return pattern;
         }
 
-        internal static IEnumerable<File> ExcludeRefDirectory(this IEnumerable<File> assemblies) =>
+        internal static IEnumerable<File> ExcludeRefDirectory(
+            this IEnumerable<File> assemblies
+        ) =>
             assemblies
                 .Where(file => !file.Directory.EndsWith("ref"));
 
-        internal static IEnumerable<File> ElseLoadReferencedAssemblies(this IEnumerable<File> assemblies, Assembly rootAssembly) =>
-            assemblies.Any()
+        internal static IEnumerable<File> ElseLoadReferencedAssemblies(
+            this IEnumerable<File> assemblies,
+            Assembly rootAssembly
+        ) => assemblies.Any()
                 ? assemblies
                 : rootAssembly
                     .GetReferencedAssemblies()
@@ -58,27 +73,37 @@ namespace Tethos
                     .Select(assembly => new Uri(assembly.CodeBase).AbsolutePath)
                     .Select(filePath => filePath.GetFile());
 
-        internal static IEnumerable<Assembly> LoadAssemblies(this IEnumerable<File> assemblies, params Assembly[] extraAssemblies) =>
-            assemblies.Select(file => file.Name)
+        internal static IEnumerable<Assembly> LoadAssemblies(
+            this IEnumerable<File> assemblies,
+            params Assembly[] extraAssemblies
+        ) => assemblies
+                .Select(file => file.Name)
                 .Select(TryToLoadAssembly)
                 .OfType<Assembly>()
                 .Union(extraAssemblies);
 
-        internal static Assembly TryToLoadAssembly(this AssemblyName assemblyName)
+        internal static Assembly TryToLoadAssembly(
+            this AssemblyName assemblyName
+        )
         {
             // TODO: Explicit Func type won't necessary in C# 10
             Func<Assembly> func = () => Assembly.Load(assemblyName);
             return func.SwallowExceptions(typeof(BadImageFormatException), typeof(FileNotFoundException));
         }
 
-        internal static Assembly TryToLoadAssembly(this string assemblyPath)
+        internal static Assembly TryToLoadAssembly(
+            this string assemblyPath
+        )
         {
             // TODO: Explicit Func type won't necessary in C# 10
             Func<Assembly> func = () => Assembly.LoadFrom(assemblyPath);
             return func.SwallowExceptions(typeof(BadImageFormatException), typeof(FileNotFoundException));
         }
 
-        internal static Assembly SwallowExceptions(this Func<Assembly> func, params Type[] types)
+        internal static Assembly SwallowExceptions(
+            this Func<Assembly> func,
+            params Type[] types
+        )
         {
             try
             {

--- a/src/Tethos/AutoMockingContainer.cs
+++ b/src/Tethos/AutoMockingContainer.cs
@@ -3,7 +3,7 @@
 namespace Tethos
 {
     /// <summary>
-    /// Auto-mocking container implementation.
+    /// Generic auto-mocking container.
     /// </summary>
     public class AutoMockingContainer : WindsorContainer, IAutoMockingContainer
     {

--- a/src/Tethos/AutoMockingContainer.cs
+++ b/src/Tethos/AutoMockingContainer.cs
@@ -3,7 +3,7 @@
 namespace Tethos
 {
     /// <summary>
-    /// Generic auto-mocking container.
+    /// Auto-mocking container implementation.
     /// </summary>
     public class AutoMockingContainer : WindsorContainer, IAutoMockingContainer
     {

--- a/src/Tethos/AutoMockingContainer.cs
+++ b/src/Tethos/AutoMockingContainer.cs
@@ -2,9 +2,7 @@
 
 namespace Tethos
 {
-    /// <summary>
-    /// Auto-mocking container implementation.
-    /// </summary>
+    /// <inheritdoc cref="IAutoMockingContainer" />
     public class AutoMockingContainer : WindsorContainer, IAutoMockingContainer
     {
     }

--- a/src/Tethos/AutoResolver.cs
+++ b/src/Tethos/AutoResolver.cs
@@ -46,7 +46,9 @@ namespace Tethos
         )
         {
             string GetType(object argument) =>
-                argument.ToString().Split(new string[] { "__" }, StringSplitOptions.None).FirstOrDefault();
+                argument.ToString()
+                .Split(new string[] { "__" }, StringSplitOptions.None)
+                .FirstOrDefault();
             var targetType = dependency.TargetType;
             var arguments = context.AdditionalArguments
                 .Where(_ => !targetType.IsInterface)

--- a/src/Tethos/AutoResolver.cs
+++ b/src/Tethos/AutoResolver.cs
@@ -26,7 +26,7 @@ namespace Tethos
         /// </summary>
         /// <param name="targetType">Target type for object to be converted to destination object.</param>
         /// <param name="constructorArguments">Constructor argument for target type in case it is non-abstract type.</param>
-        /// <returns></returns>
+        /// <returns>Auto-mocked object dependending on target type.</returns>
         public abstract object MapToTarget(Type targetType, Arguments constructorArguments);
 
         /// <inheritdoc />

--- a/src/Tethos/AutoResolver.cs
+++ b/src/Tethos/AutoResolver.cs
@@ -25,7 +25,7 @@ namespace Tethos
         /// Maps target mock object to mocked object type.
         /// </summary>
         /// <param name="targetType">Target type for object to be converted to destination object.</param>
-        /// <param name="constructorArguments">Constructor argument for target type in case it is non-abstract type.</param>
+        /// <param name="constructorArguments">Constructor arguments for non-abstract target type.</param>
         /// <returns>Auto-mocked object dependending on target type.</returns>
         public abstract object MapToTarget(Type targetType, Arguments constructorArguments);
 

--- a/src/Tethos/BaseAutoMockingTest.cs
+++ b/src/Tethos/BaseAutoMockingTest.cs
@@ -51,7 +51,9 @@ namespace Tethos
                 .ToArray()
             );
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Provides a mechanism for releasing unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);

--- a/src/Tethos/BaseAutoMockingTest.cs
+++ b/src/Tethos/BaseAutoMockingTest.cs
@@ -51,9 +51,7 @@ namespace Tethos
                 .ToArray()
             );
 
-        /// <summary>
-        /// Provides a mechanism for releasing unmanaged resources.
-        /// </summary>
+        /// <inheritdoc />
         public void Dispose()
         {
             Dispose(true);

--- a/src/Tethos/IAutoMockingContainer.cs
+++ b/src/Tethos/IAutoMockingContainer.cs
@@ -3,7 +3,7 @@
 namespace Tethos
 {
     /// <summary>
-    /// Auto-mocking container contract.
+    /// Auto-mocking container based on <see cref="IWindsorContainer"/>.
     /// </summary>
     public interface IAutoMockingContainer : IWindsorContainer
     {

--- a/src/Tethos/Tethos.csproj
+++ b/src/Tethos/Tethos.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<NoWarn>$(NoWarn);IDT001</NoWarn>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -54,4 +55,9 @@
 		</None>
 	</ItemGroup>
 
+	<!-- Following group is needed because of this: https://github.com/dotnet/standard/issues/1527 -->
+	<ItemGroup>
+		<PackageDownload Include="NETStandard.Library.Ref" Version="[2.1.0]" />
+		<InheritDocReference Include="$([MSBuild]::EnsureTrailingSlash('$(NugetPackageRoot)'))netstandard.library.ref\2.1.0\ref\netstandard2.1\netstandard.xml" />
+	</ItemGroup>
 </Project>

--- a/src/Tethos/WindsorExtensions.cs
+++ b/src/Tethos/WindsorExtensions.cs
@@ -9,6 +9,5 @@ namespace Tethos
             this ComponentRegistration<T> componentRegistration
         ) where T : class
             => componentRegistration?.Named($"{Guid.NewGuid()}").IsDefault();
-
     }
 }


### PR DESCRIPTION
Closes #42.

- [x] Fix `inheritdoc` complication errors.

```
 C:\Users\runneradmin\.nuget\packages\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.xml(654,86): InheritDocTask warning IDT001: XML parse error in referenced doc: The 'p' start tag on line 654 position 2 does not match the end tag of 'th'. Line 654, position 86. [D:\a\Tethos\Tethos\src\Tethos\Tethos.csproj]
D:\a\Tethos\Tethos\src\Tethos\obj\Release\netstandard2.0\Tethos.original.xml(69,10): InheritDocTask warning IDT002: No matching documentation could be found for: M:Tethos.BaseAutoMockingTest`1.Dispose, which attempts to inherit from: M:System.IDisposable.Dispose [D:\a\Tethos\Tethos\src\Tethos\Tethos.csproj]
  InheritDocTask replaced 3 of 4 inheritdoc tags and removed 0 non-public member docs in D:\a\Tethos\Tethos\src\Tethos\obj\Release\netstandard2.0\Tethos.xml
```