### PR TITLE
Document ContainerExtensions extensions 

### DIFF
--- a/src/Tethos/Extensions/ContainerExtensions.cs
+++ b/src/Tethos/Extensions/ContainerExtensions.cs
@@ -44,9 +44,19 @@
         /// <param name="container">Auto-mocking container instance.</param>
         /// <returns>Child type resolved instance.</returns>
         public static TChild ResolveFrom<TParent, TChild>(this IAutoMockingContainer container)
+            => (TChild)container.ResolveFrom(typeof(TParent), typeof(TChild));
+
+        /// <summary>
+        /// Resolve child depedency within parent dependency.
+        /// </summary>
+        /// <param name="container">Auto-mocking container instance.</param>
+        /// <param name="parent">Parent type of an object.</param>
+        /// <param name="child">Child type of an object.</param>
+        /// <returns>Child type resolved object.</returns>
+        public static object ResolveFrom(this IAutoMockingContainer container, Type parent, Type child)
         {
-            container.Resolve<TParent>();
-            return container.Resolve<TChild>();
+            container.Resolve(parent);
+            return container.Resolve(child);
         }
 
         internal static object[] Flatten(this Arguments arguments) =>

--- a/src/Tethos/Extensions/ContainerExtensions.cs
+++ b/src/Tethos/Extensions/ContainerExtensions.cs
@@ -5,7 +5,7 @@
     using Castle.MicroKernel;
 
     /// <summary>
-    /// A set of utils function helping to extend <see cref="Castle.Windsor.IWindsorContainer"/> for auto-mocking.
+    /// A set of util functions helping to extend <see cref="Castle.Windsor.IWindsorContainer"/> for auto-mocking.
     /// </summary>
     public static class ContainerExtensions
     {
@@ -35,6 +35,19 @@
                 var parameterName when string.IsNullOrWhiteSpace(parameterName) => throw new ArgumentNullException(nameof(name)),
                 var parameterName => arguments.AddNamed($"{sourceType}__{parameterName}", value),
             };
+
+        /// <summary>
+        /// Resolve child depedency within parent dependency.
+        /// </summary>
+        /// <typeparam name="TParent">Parent type to use.</typeparam>
+        /// <typeparam name="TChild">Child type to resolve.</typeparam>
+        /// <param name="container">Auto-mocking container instance.</param>
+        /// <returns>Child type resolved instance.</returns>
+        public static TChild ResolveFrom<TParent, TChild>(this IAutoMockingContainer container)
+        {
+            container.Resolve<TParent>();
+            return container.Resolve<TChild>();
+        }
 
         internal static object[] Flatten(this Arguments arguments) =>
             arguments.Select(argument => argument.Value).ToArray();

--- a/src/Tethos/Extensions/WindsorExtensions.cs
+++ b/src/Tethos/Extensions/WindsorExtensions.cs
@@ -3,24 +3,8 @@
     using System;
     using Castle.MicroKernel.Registration;
 
-    /// <summary>
-    /// TODO: Docs
-    /// </summary>
-    public static class WindsorExtensions
+    internal static class WindsorExtensions
     {
-        /// <summary>
-        /// TODO: Docs
-        /// </summary>
-        /// <typeparam name="TParent"></typeparam>
-        /// <typeparam name="TChild"></typeparam>
-        /// <param name="container"></param>
-        /// <returns></returns>
-        public static TChild ResolveFrom<TParent, TChild>(this IAutoMockingContainer container)
-        {
-            container.Resolve<TParent>();
-            return container.Resolve<TChild>();
-        }
-
         internal static ComponentRegistration<T> OverridesExistingRegistration<T>(
             this ComponentRegistration<T> componentRegistration)
             where T : class => componentRegistration?.Named($"{Guid.NewGuid()}").IsDefault();

--- a/test/Tethos.Tests/Extensions/ContainerExtensionsTests.cs
+++ b/test/Tethos.Tests/Extensions/ContainerExtensionsTests.cs
@@ -5,7 +5,9 @@
     using AutoFixture.Xunit2;
     using Castle.MicroKernel;
     using FluentAssertions;
+    using Moq;
     using Tethos.Extensions;
+    using Tethos.Tests.Attributes;
     using Xunit;
 
     public class ContainerExtensionsTests
@@ -92,6 +94,41 @@
 
             // Assert
             actual.Should().Throw<ArgumentNullException>();
+        }
+
+        [Theory]
+        [AutoMoqData]
+        [Trait("Category", "Unit")]
+        public void ResolveFrom_UsingGenerics_ShouldMatch(int expected, Mock<IAutoMockingContainer> mock)
+        {
+            // Arrange
+            var childType = expected.GetType();
+            var parentType = typeof(string);
+            mock.Setup(m => m.Resolve(childType)).Returns(expected);
+
+            // Act
+            var actual = mock.Object.ResolveFrom<string, int>();
+
+            // Assert
+            mock.Verify(m => m.Resolve(parentType), Times.Once);
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [AutoMoqData]
+        [Trait("Category", "Unit")]
+        public void ResolveFrom_UsingTypeParams_ShouldMatch(int expected, Type parent, Mock<IAutoMockingContainer> mock)
+        {
+            // Arrange
+            var childType = expected.GetType();
+            mock.Setup(m => m.Resolve(childType)).Returns(expected);
+
+            // Act
+            var actual = mock.Object.ResolveFrom(parent, childType);
+
+            // Assert
+            mock.Verify(m => m.Resolve(parent), Times.Once);
+            actual.Should().Be(expected);
         }
 
         [Theory]


### PR DESCRIPTION
Closes #86.

- [x] Move `ResolveFrom` to `ContainerExtensions` class
- [x] Document `ResolveFrom` function
- [x] Fix docs typo in `ContainerExtensions` class
- [x] Add unit tests