### PR TITLE
Update check-spelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,14 +153,20 @@ jobs:
 
   spellcheck:
     name: 🔦 Spellcheck
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    outputs:
+      followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
     steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v3
-
       - name: ✅ Check spelling
-        uses: check-spelling/check-spelling@v0.0.20-alpha4
+        id: spelling
+        uses: check-spelling/check-spelling@v0.0.20
         with:
+          checkout: true
+          post_comment: 0
           extra_dictionaries: cspell:csharp/csharp.txt
             cspell:companies/companies.txt
             cspell:dotnet/dotnet.txt
@@ -168,6 +174,21 @@ jobs:
             cspell:fullstack/fullstack.txt
             cspell:html/html.txt
             cspell:software-terms/softwareTerms.txt
+  spellcheck-comment:
+    name: 💬 Spellcheck
+    runs-on: ubuntu-latest
+    needs: spellcheck
+    permissions:
+      contents: write
+      pull-requests: write
+    if: (success() || failure()) && needs.spellcheck.outputs.followup
+    steps:
+      - name: 💬 Report
+        uses: check-spelling/check-spelling@v0.0.20
+        with:
+          checkout: true
+          task: ${{ needs.spellcheck.outputs.followup }}
+
   lint-yml:
     name: 🐞 YML
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             cspell:filetypes/filetypes.txt
             cspell:fullstack/fullstack.txt
             cspell:html/html.txt
-            cspell:software-terms/software-terms.txt
+            cspell:software-terms/softwareTerms.txt
   lint-yml:
     name: 🐞 YML
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi,

I see you're using an alpha release. I released [check-spelling@v0.0.20](https://github.com/check-spelling/check-spelling/releases/tag/v0.0.20) a month ago and I'd like to migrate people to that release.

There are a couple of changes here:
* update a cspell dictionary reference -- until quite late, I didn't flag missing dictionaries.
* applying permissions and splitting the workflow (this is very important)
* adding an `id`. Note that `id` and `name` are quite different. `outputs` are referenced from `id` fields, whereas the primary display value comes from `name`.
* folding `actions/checkout` into the action https://github.com/check-spelling/check-spelling/blob/729687234a293e0680b12ca055a02fff415da89d/action.yml#L220-L230

The iconography is arbitrary, but I'm trying to match the style of this file.

Testing was performed in https://github.com/check-spelling/Tethos/commit/93974d84ea3dc29e66ebe0070639064a99777b6c