### PR TITLE
Use FluentAssertions v7 only

### DIFF
--- a/test/ReferencedAssemblies.FakeItEasy.Tests/ReferencedAssemblies.FakeItEasy.Tests.csproj
+++ b/test/ReferencedAssemblies.FakeItEasy.Tests/ReferencedAssemblies.FakeItEasy.Tests.csproj
@@ -12,7 +12,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/ReferencedAssemblies.Moq.Tests/ReferencedAssemblies.Moq.Tests.csproj
+++ b/test/ReferencedAssemblies.Moq.Tests/ReferencedAssemblies.Moq.Tests.csproj
@@ -12,7 +12,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/ReferencedAssemblies.NSubstitute.Tests/ReferencedAssemblies.NSubstitute.Tests.csproj
+++ b/test/ReferencedAssemblies.NSubstitute.Tests/ReferencedAssemblies.NSubstitute.Tests.csproj
@@ -12,7 +12,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/ReferencedAssemblies.Tests/ReferencedAssemblies.Tests.csproj
+++ b/test/ReferencedAssemblies.Tests/ReferencedAssemblies.Tests.csproj
@@ -12,7 +12,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Tethos.FakeItEasy.Tests/Tethos.FakeItEasy.Tests.csproj
+++ b/test/Tethos.FakeItEasy.Tests/Tethos.FakeItEasy.Tests.csproj
@@ -19,7 +19,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Tethos.Moq.Tests/Tethos.Moq.Tests.csproj
+++ b/test/Tethos.Moq.Tests/Tethos.Moq.Tests.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Tethos.NSubstitute.Tests/Tethos.NSubstitute.Tests.csproj
+++ b/test/Tethos.NSubstitute.Tests/Tethos.NSubstitute.Tests.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Tethos.PerformanceTests/Tethos.PerformanceTests.csproj
+++ b/test/Tethos.PerformanceTests/Tethos.PerformanceTests.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Tethos.Tests/Tethos.Tests.csproj
+++ b/test/Tethos.Tests/Tethos.Tests.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="7.*" />
 		<PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
For now pinning FluentAssertions v7 because of license change: https://github.com/fluentassertions/fluentassertions/pull/2943

Planning to move to [Shouldly](https://github.com/shouldly).